### PR TITLE
Feat/expansion toggle

### DIFF
--- a/app/components/dashboard/index.tsx
+++ b/app/components/dashboard/index.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import MatchTiles from '../match-tiles';
+import { MatchResponse } from '@/interfaces/match.interface';
+
+interface DashboardProps {
+  matches: MatchResponse[];
+}
+
+type ExpandedMap = Record<number, boolean>;
+
+type ExpandedMapStates = {
+  ALL_EXPANDED: ExpandedMap;
+  ALL_COLLAPSED: ExpandedMap;
+};
+
+const Dashboard = ({ matches }: DashboardProps) => {
+  const expandedMapStates: ExpandedMapStates = useMemo(
+    () =>
+      matches.reduce(
+        (states, match) => ({
+          ALL_EXPANDED: { ...states.ALL_EXPANDED, [match.id]: true },
+          ALL_COLLAPSED: { ...states.ALL_COLLAPSED, [match.id]: false },
+        }),
+        { ALL_EXPANDED: {}, ALL_COLLAPSED: {} },
+      ),
+    [matches],
+  );
+
+  const [expandedMap, setExpandedMap] = useState(
+    expandedMapStates.ALL_COLLAPSED,
+  );
+
+  const hasAllTilesExpanded = useMemo(() => {
+    return matches.every((match) => expandedMap[match.id]);
+  }, [expandedMap, matches]);
+
+  const handleToggleAll = () => {
+    setExpandedMap(
+      hasAllTilesExpanded
+        ? expandedMapStates.ALL_COLLAPSED
+        : expandedMapStates.ALL_EXPANDED,
+    );
+  };
+
+  const handleToggleMatchTile = (matchId: number) => {
+    setExpandedMap((previousMap) => {
+      return { ...previousMap, [matchId]: !previousMap[matchId] };
+    });
+  };
+
+  return (
+    <div>
+      <div className="u-py-5">
+        <input
+          type="text"
+          className="u-py-3 u-px-7 u-w-full u-bg-green-300 u-rounded-full"
+          placeholder="Search for a team"
+        />
+      </div>
+
+      <button
+        className="u-block u-ml-auto u-mb-5 u-py-3 u-px-7 u-bg-green-900 u-rounded"
+        onClick={handleToggleAll}
+      >
+        {hasAllTilesExpanded ? 'Collapse' : 'Expand'} All
+      </button>
+
+      <MatchTiles
+        matches={matches}
+        expandedMap={expandedMap}
+        onToggleMatchTile={handleToggleMatchTile}
+      />
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/app/components/dashboard/index.tsx
+++ b/app/components/dashboard/index.tsx
@@ -57,7 +57,7 @@ const Dashboard = ({ matches }: DashboardProps) => {
       </div>
 
       <button
-        className="u-block u-ml-auto u-mb-5 u-py-3 u-px-7 u-bg-green-900 u-rounded"
+        className="u-block u-ml-auto u-mb-5 u-py-3 u-px-7 u-w-40 u-bg-green-900 u-rounded"
         onClick={handleToggleAll}
       >
         {hasAllTilesExpanded ? 'Collapse' : 'Expand'} All

--- a/app/components/dashboard/index.tsx
+++ b/app/components/dashboard/index.tsx
@@ -3,31 +3,32 @@
 import { useMemo, useState } from 'react';
 import MatchTiles from '../match-tiles';
 import { MatchResponse } from '@/interfaces/match.interface';
-import { ExpandedMapStates } from '@/interfaces/ui.type';
+import { ExpandedMap, ExpandedMapStates } from '@/interfaces/ui.type';
 
 interface DashboardProps {
   matches: MatchResponse[];
 }
 
 const Dashboard = ({ matches }: DashboardProps) => {
-  const expandedMapStates: ExpandedMapStates = useMemo(
-    () =>
-      matches.reduce(
-        (states, match) => ({
-          ALL_EXPANDED: { ...states.ALL_EXPANDED, [match.id]: true },
-          ALL_COLLAPSED: { ...states.ALL_COLLAPSED, [match.id]: false },
-        }),
-        { ALL_EXPANDED: {}, ALL_COLLAPSED: {} },
-      ),
-    [matches],
-  );
+  const expandedMapStates: ExpandedMapStates = useMemo(() => {
+    const states: ExpandedMapStates = {
+      ALL_EXPANDED: new Map(),
+      ALL_COLLAPSED: new Map(),
+    };
+    matches.forEach((match) => {
+      states.ALL_EXPANDED.set(match.id, true);
+      states.ALL_COLLAPSED.set(match.id, false);
+    });
+
+    return states;
+  }, [matches]);
 
   const [expandedMap, setExpandedMap] = useState(
     expandedMapStates.ALL_COLLAPSED,
   );
 
   const hasAllTilesExpanded = useMemo(() => {
-    return matches.every((match) => expandedMap[match.id]);
+    return matches.every((match) => expandedMap.get(match.id));
   }, [expandedMap, matches]);
 
   const handleToggleAll = () => {
@@ -40,7 +41,8 @@ const Dashboard = ({ matches }: DashboardProps) => {
 
   const handleToggleMatchTile = (matchId: number) => {
     setExpandedMap((previousMap) => {
-      return { ...previousMap, [matchId]: !previousMap[matchId] };
+      const newMap: ExpandedMap = new Map(previousMap);
+      return newMap.set(matchId, !previousMap.get(matchId));
     });
   };
 

--- a/app/components/dashboard/index.tsx
+++ b/app/components/dashboard/index.tsx
@@ -3,17 +3,11 @@
 import { useMemo, useState } from 'react';
 import MatchTiles from '../match-tiles';
 import { MatchResponse } from '@/interfaces/match.interface';
+import { ExpandedMapStates } from '@/interfaces/ui.type';
 
 interface DashboardProps {
   matches: MatchResponse[];
 }
-
-type ExpandedMap = Record<number, boolean>;
-
-type ExpandedMapStates = {
-  ALL_EXPANDED: ExpandedMap;
-  ALL_COLLAPSED: ExpandedMap;
-};
 
 const Dashboard = ({ matches }: DashboardProps) => {
   const expandedMapStates: ExpandedMapStates = useMemo(

--- a/app/components/match-tiles/index.tsx
+++ b/app/components/match-tiles/index.tsx
@@ -1,19 +1,44 @@
-import { Suspense } from 'react';
-import MatchTile from './match-tile';
+'use client';
+
+import { Suspense, useMemo, useState } from 'react';
+import dynamic from 'next/dynamic';
 import Loading from './loading';
 import { MatchResponse } from '@/interfaces/match.interface';
+
+const MatchTile = dynamic(() => import('./match-tile'), { ssr: false });
 
 interface MatchTilesProps {
   matches?: MatchResponse[];
 }
 
 const MatchTiles = ({ matches = [] }: MatchTilesProps) => {
+  const initialExpandedMap: Record<number, boolean> = useMemo(
+    () =>
+      matches.reduce((subMap, match) => ({ ...subMap, [match.id]: false }), {}),
+    [matches],
+  );
+
+  const [expandedMap, setExpandedMap] = useState(initialExpandedMap);
+
+  const handleToggleMatchTile = (matchId: number) => {
+    setExpandedMap((previousMap) => {
+      return { ...previousMap, [matchId]: !previousMap[matchId] };
+    });
+  };
+
   return (
     <div className="u-py-5 u-px-7 u-bg-green-100 u-rounded-xl u-flex u-flex-col u-gap-5">
       <Suspense fallback={<Loading />}>
         {!matches.length
           ? 'No matches data found'
-          : matches.map((match) => <MatchTile key={match.id} match={match} />)}
+          : matches.map((match, idx) => (
+              <MatchTile
+                key={`${idx}-${match.id}`}
+                match={match}
+                isExpanded={expandedMap[match.id]}
+                onToggleMatchTile={handleToggleMatchTile}
+              />
+            ))}
       </Suspense>
     </div>
   );

--- a/app/components/match-tiles/index.tsx
+++ b/app/components/match-tiles/index.tsx
@@ -8,7 +8,7 @@ const MatchTile = dynamic(() => import('./match-tile'), { ssr: false });
 interface MatchTilesProps {
   matches?: MatchResponse[];
   expandedMap: Record<number, boolean>;
-  onToggleMatchTile?: (matchId: number) => void;
+  onToggleMatchTile: (matchId: number) => void;
 }
 
 const MatchTiles = ({

--- a/app/components/match-tiles/index.tsx
+++ b/app/components/match-tiles/index.tsx
@@ -2,12 +2,13 @@ import { Suspense } from 'react';
 import dynamic from 'next/dynamic';
 import Loading from './loading';
 import { MatchResponse } from '@/interfaces/match.interface';
+import { ExpandedMap } from '@/interfaces/ui.type';
 
 const MatchTile = dynamic(() => import('./match-tile'), { ssr: false });
 
 interface MatchTilesProps {
   matches?: MatchResponse[];
-  expandedMap: Record<number, boolean>;
+  expandedMap: ExpandedMap;
   onToggleMatchTile: (matchId: number) => void;
 }
 

--- a/app/components/match-tiles/index.tsx
+++ b/app/components/match-tiles/index.tsx
@@ -1,6 +1,4 @@
-'use client';
-
-import { Suspense, useMemo, useState } from 'react';
+import { Suspense } from 'react';
 import dynamic from 'next/dynamic';
 import Loading from './loading';
 import { MatchResponse } from '@/interfaces/match.interface';
@@ -9,23 +7,15 @@ const MatchTile = dynamic(() => import('./match-tile'), { ssr: false });
 
 interface MatchTilesProps {
   matches?: MatchResponse[];
+  expandedMap: Record<number, boolean>;
+  onToggleMatchTile?: (matchId: number) => void;
 }
 
-const MatchTiles = ({ matches = [] }: MatchTilesProps) => {
-  const initialExpandedMap: Record<number, boolean> = useMemo(
-    () =>
-      matches.reduce((subMap, match) => ({ ...subMap, [match.id]: false }), {}),
-    [matches],
-  );
-
-  const [expandedMap, setExpandedMap] = useState(initialExpandedMap);
-
-  const handleToggleMatchTile = (matchId: number) => {
-    setExpandedMap((previousMap) => {
-      return { ...previousMap, [matchId]: !previousMap[matchId] };
-    });
-  };
-
+const MatchTiles = ({
+  matches = [],
+  expandedMap,
+  onToggleMatchTile,
+}: MatchTilesProps) => {
   return (
     <div className="u-py-5 u-px-7 u-bg-green-100 u-rounded-xl u-flex u-flex-col u-gap-5">
       <Suspense fallback={<Loading />}>
@@ -36,7 +26,7 @@ const MatchTiles = ({ matches = [] }: MatchTilesProps) => {
                 key={`${idx}-${match.id}`}
                 match={match}
                 isExpanded={expandedMap[match.id]}
-                onToggleMatchTile={handleToggleMatchTile}
+                onToggleMatchTile={onToggleMatchTile}
               />
             ))}
       </Suspense>

--- a/app/components/match-tiles/index.tsx
+++ b/app/components/match-tiles/index.tsx
@@ -26,7 +26,7 @@ const MatchTiles = ({
               <MatchTile
                 key={`${idx}-${match.id}`}
                 match={match}
-                isExpanded={expandedMap[match.id]}
+                isExpanded={expandedMap.get(match.id) ?? false}
                 onToggleMatchTile={onToggleMatchTile}
               />
             ))}

--- a/app/components/match-tiles/match-tile.tsx
+++ b/app/components/match-tiles/match-tile.tsx
@@ -1,4 +1,3 @@
-// 'use client';
 import Image from 'next/image';
 import { MatchResponse } from '@/interfaces/match.interface';
 
@@ -88,17 +87,23 @@ const MatchTile = ({
           </div>
 
           <button className="u-w-5 u-h-5" onClick={handleToggleClick(match.id)}>
-            V
+            <p
+              className={`u-text-green-600 u-font-bold u-transition-transform ${
+                isExpanded ? 'u-rotate-180' : 'u-rotate-0'
+              }`}
+            >
+              V
+            </p>
           </button>
         </div>
       </div>
 
       <div
-        className={`u-overflow-hidden ${
-          isExpanded ? 'u-max-h-full' : 'u-max-h-0'
+        className={`u-h-full u-bg-gray-800 u-text-white u-overflow-hidden u-transition-[max-height] ${
+          isExpanded ? 'u-max-h-16' : 'u-max-h-0'
         }`}
       >
-        Expanded content
+        <p className="u-py-3 u-px-7">Expanded content</p>
       </div>
     </div>
   );

--- a/app/components/match-tiles/match-tile.tsx
+++ b/app/components/match-tiles/match-tile.tsx
@@ -1,71 +1,104 @@
+// 'use client';
 import Image from 'next/image';
 import { MatchResponse } from '@/interfaces/match.interface';
 
 interface MatchTileProps {
   match: MatchResponse;
+  isExpanded: boolean;
+  onToggleMatchTile?: (matchId: number) => void;
 }
-const MatchTile = ({ match }: MatchTileProps) => {
+const MatchTile = ({
+  match,
+  isExpanded = false,
+  onToggleMatchTile,
+}: MatchTileProps) => {
+  const dateTimeFormatOptions: Intl.DateTimeFormatOptions = {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  };
+
+  const handleToggleClick = (matchId: number) => () =>
+    onToggleMatchTile && onToggleMatchTile(matchId);
+
   return (
     <div className="u-py-3 u-px-7 u-bg-green-50 u-rounded-xl u-border u-text-slate-900 u-shadow">
-      <p className="u-text-xs u-flex u-justify-between">
-        <span>
-          Start Date: {new Date(match.startTime).toLocaleDateString()}
-          {new Date(match.startTime).toLocaleTimeString()}
-        </span>
-        <span>
-          Last updated: {new Date(match.lastUpdated).toLocaleDateString()}
-          {new Date(match.lastUpdated).toLocaleTimeString()}
-        </span>
-      </p>
+      <div>
+        <p className="u-text-xs u-flex u-justify-between">
+          <span>
+            Start Date:{' '}
+            {new Date(match.startTime).toLocaleString(
+              undefined,
+              dateTimeFormatOptions,
+            )}
+          </span>
+          <span>
+            Last updated:{' '}
+            {new Date(match.lastUpdated).toLocaleString(
+              undefined,
+              dateTimeFormatOptions,
+            )}
+          </span>
+        </p>
 
-      <div className="u-flex u-items-center u-justify-between u-gap-3">
-        <div className="u-flex-1 u-flex u-items-stretch u-justify-between u-gap-3">
-          <div className="u-flex-1 u-flex u-flex-col u-justify-between u-gap-3">
-            <div className="u-text-sm u-text-center u-font-bold">Home</div>
+        <div className="u-flex u-items-center u-justify-between u-gap-3">
+          <div className="u-flex-1 u-flex u-items-stretch u-justify-between u-gap-3">
+            <div className="u-flex-1 u-flex u-flex-col u-justify-between u-gap-3">
+              <div className="u-text-sm u-text-center u-font-bold">Home</div>
 
-            <div className="u-flex u-items-center u-gap-3">
-              <Image
-                src={match.home.logo}
-                alt={match.home.name}
-                width={30}
-                height={30}
-              />
-              <h2 className="u-text-lg u-font-bold">{match.home.name}</h2>
+              <div className="u-flex u-items-center u-gap-3">
+                <Image
+                  src={match.home.logo}
+                  alt={match.home.name}
+                  width={30}
+                  height={30}
+                />
+                <h2 className="u-text-lg u-font-bold">{match.home.name}</h2>
+              </div>
+
+              <div className="u-text-3xl u-text-center">
+                {match.odds[match.odds.length - 1].home}
+              </div>
             </div>
 
-            <div className="u-text-3xl u-text-center">
-              {match.odds[match.odds.length - 1].home}
+            <div className="u-flex-1 u-flex u-flex-col u-justify-between u-gap-3">
+              <div className="u-text-sm u-text-center u-font-bold">Away</div>
+
+              <div className="u-flex u-items-center u-gap-3">
+                <Image
+                  src={match.away.logo}
+                  alt={match.away.name}
+                  width={30}
+                  height={30}
+                />
+                <h2 className="u-text-lg u-font-bold">{match.away.name}</h2>
+              </div>
+
+              <div className="u-text-3xl u-text-center">
+                {match.odds[match.odds.length - 1].away}
+              </div>
+            </div>
+
+            <div className="u-flex-1 u-flex u-flex-col u-justify-between u-gap-3">
+              <div className="u-text-sm u-text-center u-font-bold">Draw</div>
+
+              <div className="u-text-3xl u-text-center">
+                {match.odds[match.odds.length - 1].draw}
+              </div>
             </div>
           </div>
 
-          <div className="u-flex-1 u-flex u-flex-col u-justify-between u-gap-3">
-            <div className="u-text-sm u-text-center u-font-bold">Away</div>
-
-            <div className="u-flex u-items-center u-gap-3">
-              <Image
-                src={match.away.logo}
-                alt={match.away.name}
-                width={30}
-                height={30}
-              />
-              <h2 className="u-text-lg u-font-bold">{match.away.name}</h2>
-            </div>
-
-            <div className="u-text-3xl u-text-center">
-              {match.odds[match.odds.length - 1].away}
-            </div>
-          </div>
-
-          <div className="u-flex-1 u-flex u-flex-col u-justify-between u-gap-3">
-            <div className="u-text-sm u-text-center u-font-bold">Draw</div>
-
-            <div className="u-text-3xl u-text-center">
-              {match.odds[match.odds.length - 1].draw}
-            </div>
-          </div>
+          <button className="u-w-5 u-h-5" onClick={handleToggleClick(match.id)}>
+            V
+          </button>
         </div>
+      </div>
 
-        <button className="u-w-5 u-h-5">V</button>
+      <div
+        className={`u-overflow-hidden ${
+          isExpanded ? 'u-max-h-full' : 'u-max-h-0'
+        }`}
+      >
+        Expanded content
       </div>
     </div>
   );

--- a/app/components/match-tiles/match-tile.tsx
+++ b/app/components/match-tiles/match-tile.tsx
@@ -4,7 +4,7 @@ import { MatchResponse } from '@/interfaces/match.interface';
 interface MatchTileProps {
   match: MatchResponse;
   isExpanded: boolean;
-  onToggleMatchTile?: (matchId: number) => void;
+  onToggleMatchTile: (matchId: number) => void;
 }
 const MatchTile = ({
   match,
@@ -16,8 +16,7 @@ const MatchTile = ({
     timeStyle: 'short',
   };
 
-  const handleToggleClick = (matchId: number) => () =>
-    onToggleMatchTile && onToggleMatchTile(matchId);
+  const handleToggleClick = () => onToggleMatchTile(match.id);
 
   return (
     <div className="u-py-3 u-px-7 u-bg-green-50 u-rounded-xl u-border u-text-slate-900 u-shadow">
@@ -86,7 +85,7 @@ const MatchTile = ({
             </div>
           </div>
 
-          <button className="u-w-5 u-h-5" onClick={handleToggleClick(match.id)}>
+          <button className="u-w-5 u-h-5" onClick={handleToggleClick}>
             <p
               className={`u-text-green-600 u-font-bold u-transition-transform ${
                 isExpanded ? 'u-rotate-180' : 'u-rotate-0'

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
-import MatchTiles from '@/app/components/match-tiles';
 import MatchResponseData from '@/interfaces/response.interface';
+import Dashboard from './components/dashboard';
 
 async function fetchAllMatches(): Promise<MatchResponseData> {
   const res = await fetch(`${process.env.NEXT_PUBLIC_BET_BETTER_API}/matches`);
@@ -16,19 +16,7 @@ const Home = async () => {
     <main className="u-py-7 u-px-9">
       <h1 className="u-text-xl">BetBetter</h1>
 
-      <div className="u-py-5">
-        <input
-          type="text"
-          className="u-py-3 u-px-7 u-w-full u-bg-green-300 u-rounded-full"
-          placeholder="Search for a team"
-        />
-      </div>
-
-      <button className="u-block u-ml-auto u-mb-5 u-py-3 u-px-7 u-bg-green-900 u-rounded">
-        Expand All
-      </button>
-
-      <MatchTiles matches={matches} />
+      <Dashboard matches={matches} />
     </main>
   );
 };

--- a/interfaces/ui.type.ts
+++ b/interfaces/ui.type.ts
@@ -1,0 +1,6 @@
+export type ExpandedMap = Record<number, boolean>;
+
+export type ExpandedMapStates = {
+  ALL_EXPANDED: ExpandedMap;
+  ALL_COLLAPSED: ExpandedMap;
+};

--- a/interfaces/ui.type.ts
+++ b/interfaces/ui.type.ts
@@ -1,4 +1,4 @@
-export type ExpandedMap = Record<number, boolean>;
+export type ExpandedMap = Map<number, boolean>;
 
 export type ExpandedMapStates = {
   ALL_EXPANDED: ExpandedMap;


### PR DESCRIPTION
### Descriptions
- Implement the expand/collapse logic of the `MatchTile` component's toggle and the toggle all button

### Related
- https://github.com/betterbettor/bet-better-react/issues/11

### Stories
- [x] implement `expandedMap` state to control the expand/collapse toggle in the `MatchTiles`
- [x] extract `Dashboard` component and implement expand/collapse all toggle

### Screenshots
|Before|After|
|-|-|
| <video src="https://github.com/betterbettor/bet-better-react/assets/47293355/a0a05797-d5c5-4a78-bd3a-11a28ff05014" /> | <video src="https://github.com/betterbettor/bet-better-react/assets/47293355/059fd9ef-91e2-4533-af33-ea75d120df7f" /> |

